### PR TITLE
Make `serde` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ categories = ["cryptography"]
 keywords = ["crypto", "bulletproofs", "rangeproofs", "zeroknowledge", "zkp"]
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = [ "serde" ]
+serde = ["dep:serde_json", "dep:serde"]
 
 [dependencies]
-k256 = { version = "0.13.3", features = ["serde"]}
+k256 = { version = "0.13.3", features = ["serde"] }
 sha2 = "0.10.8"
 merlin = "3.0.0"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
+
+serde = { version = "1.0.197", features = ["derive"], optional = true }
+serde_json = { version = "1.0.114", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 
 [features]
 default = [ "serde" ]
-serde = ["dep:serde_json", "dep:serde"]
+serde = ["dep:serde_json", "dep:serde", "k256/serde"]
 
 [dependencies]
-k256 = { version = "0.13.3", features = ["serde"] }
+k256 = { version = "0.13.3" }
 sha2 = "0.10.8"
 merlin = "3.0.0"
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -2,13 +2,19 @@
 ///! Definition and implementation of the Bulletproofs++ arithmetic circuit protocol.
 
 use std::ops::{Add, Mul, Sub};
-use k256::{AffinePoint, ProjectivePoint, Scalar};
+use k256::{ProjectivePoint, Scalar};
 use k256::elliptic_curve::rand_core::{CryptoRng, RngCore};
 use merlin::Transcript;
-use serde::{Deserialize, Serialize};
+
 use crate::util::*;
 use crate::{transcript, wnla};
 use crate::wnla::WeightNormLinearArgument;
+
+#[cfg(feature = "serde")]
+mod serializable;
+
+#[cfg(feature = "serde")]
+pub use serializable::SerializableProof;
 
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub enum PartitionType {
@@ -29,49 +35,6 @@ pub struct Proof {
     pub x: Vec<ProjectivePoint>,
     pub l: Vec<Scalar>,
     pub n: Vec<Scalar>,
-}
-
-/// Represent serializable version of arithmetic circuit proof (uses AffinePoint instead of ProjectivePoint).
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SerializableProof {
-    pub c_l: AffinePoint,
-    pub c_r: AffinePoint,
-    pub c_o: AffinePoint,
-    pub c_s: AffinePoint,
-    pub r: Vec<AffinePoint>,
-    pub x: Vec<AffinePoint>,
-    pub l: Vec<Scalar>,
-    pub n: Vec<Scalar>,
-}
-
-impl From<&SerializableProof> for Proof {
-    fn from(value: &SerializableProof) -> Self {
-        return Proof {
-            c_l: ProjectivePoint::from(&value.c_l),
-            c_r: ProjectivePoint::from(&value.c_r),
-            c_o: ProjectivePoint::from(&value.c_o),
-            c_s: ProjectivePoint::from(&value.c_s),
-            r: value.r.iter().map(|r_val| ProjectivePoint::from(r_val)).collect::<Vec<ProjectivePoint>>(),
-            x: value.x.iter().map(|x_val| ProjectivePoint::from(x_val)).collect::<Vec<ProjectivePoint>>(),
-            l: value.l.clone(),
-            n: value.n.clone(),
-        };
-    }
-}
-
-impl From<&Proof> for SerializableProof {
-    fn from(value: &Proof) -> Self {
-        return SerializableProof {
-            c_l: value.c_l.to_affine(),
-            c_r: value.c_r.to_affine(),
-            c_o: value.c_o.to_affine(),
-            c_s: value.c_s.to_affine(),
-            r: value.r.iter().map(|r_val| r_val.to_affine()).collect::<Vec<AffinePoint>>(),
-            x: value.x.iter().map(|x_val| x_val.to_affine()).collect::<Vec<AffinePoint>>(),
-            l: value.l.clone(),
-            n: value.n.clone(),
-        };
-    }
 }
 
 /// Represents arithmetic circuit witness.

--- a/src/circuit/serializable.rs
+++ b/src/circuit/serializable.rs
@@ -1,0 +1,46 @@
+use k256::{AffinePoint, ProjectivePoint, Scalar};
+
+use super::Proof;
+
+/// Represent serializable version of arithmetic circuit proof (uses AffinePoint instead of ProjectivePoint).
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct SerializableProof {
+    pub c_l: AffinePoint,
+    pub c_r: AffinePoint,
+    pub c_o: AffinePoint,
+    pub c_s: AffinePoint,
+    pub r: Vec<AffinePoint>,
+    pub x: Vec<AffinePoint>,
+    pub l: Vec<Scalar>,
+    pub n: Vec<Scalar>,
+}
+
+impl From<&SerializableProof> for Proof {
+    fn from(value: &SerializableProof) -> Self {
+        return Proof {
+            c_l: ProjectivePoint::from(&value.c_l),
+            c_r: ProjectivePoint::from(&value.c_r),
+            c_o: ProjectivePoint::from(&value.c_o),
+            c_s: ProjectivePoint::from(&value.c_s),
+            r: value.r.iter().map(|r_val| ProjectivePoint::from(r_val)).collect::<Vec<ProjectivePoint>>(),
+            x: value.x.iter().map(|x_val| ProjectivePoint::from(x_val)).collect::<Vec<ProjectivePoint>>(),
+            l: value.l.clone(),
+            n: value.n.clone(),
+        };
+    }
+}
+
+impl From<&Proof> for SerializableProof {
+    fn from(value: &Proof) -> Self {
+        return SerializableProof {
+            c_l: value.c_l.to_affine(),
+            c_r: value.c_r.to_affine(),
+            c_o: value.c_o.to_affine(),
+            c_s: value.c_s.to_affine(),
+            r: value.r.iter().map(|r_val| r_val.to_affine()).collect::<Vec<AffinePoint>>(),
+            x: value.x.iter().map(|x_val| x_val.to_affine()).collect::<Vec<AffinePoint>>(),
+            l: value.l.clone(),
+            n: value.n.clone(),
+        };
+    }
+}

--- a/src/range_proof.rs
+++ b/src/range_proof.rs
@@ -1,2 +1,8 @@
 pub mod reciprocal;
 pub mod u64_proof;
+
+#[cfg(feature = "serde")]
+mod serializable;
+
+#[cfg(feature = "serde")]
+pub use serializable::SerializableProof;

--- a/src/range_proof/reciprocal.rs
+++ b/src/range_proof/reciprocal.rs
@@ -3,10 +3,9 @@
 ///! Definition and implementation of the reciprocal range-proof protocol based on arithmetic circuits protocol.
 
 use std::ops::{Add, Mul};
-use k256::{AffinePoint, ProjectivePoint, Scalar};
+use k256::{ProjectivePoint, Scalar};
 use k256::elliptic_curve::rand_core::{CryptoRng, RngCore};
 use merlin::Transcript;
-use serde::{Deserialize, Serialize};
 use crate::util::*;
 use crate::{circuit, transcript};
 use crate::circuit::{ArithmeticCircuit, PartitionType};
@@ -29,32 +28,6 @@ pub struct Witness {
 pub struct Proof {
     pub circuit_proof: circuit::Proof,
     pub r: ProjectivePoint,
-}
-
-/// Represent serializable version of reciprocal proof (uses AffinePoint instead of ProjectivePoint
-/// and serialized version of circuit proof).
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SerializableProof {
-    pub circuit_proof: circuit::SerializableProof,
-    pub r: AffinePoint,
-}
-
-impl From<&SerializableProof> for Proof {
-    fn from(value: &SerializableProof) -> Self {
-        return Proof {
-            circuit_proof: circuit::Proof::from(&value.circuit_proof),
-            r: ProjectivePoint::from(value.r),
-        };
-    }
-}
-
-impl From<&Proof> for SerializableProof {
-    fn from(value: &Proof) -> Self {
-        return SerializableProof {
-            circuit_proof: circuit::SerializableProof::from(&value.circuit_proof),
-            r: value.r.to_affine(),
-        };
-    }
 }
 
 /// Represents public reciprocal range proof protocol information. Using this information and challenge

--- a/src/range_proof/serializable.rs
+++ b/src/range_proof/serializable.rs
@@ -1,0 +1,32 @@
+use k256::{AffinePoint, ProjectivePoint};
+
+use crate::circuit;
+
+use super::reciprocal::Proof;
+
+
+/// Represent serializable version of reciprocal proof (uses AffinePoint instead of ProjectivePoint
+/// and serialized version of circuit proof).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SerializableProof {
+    pub circuit_proof: circuit::SerializableProof,
+    pub r: AffinePoint,
+}
+
+impl From<&SerializableProof> for Proof {
+    fn from(value: &SerializableProof) -> Self {
+        return Proof {
+            circuit_proof: circuit::Proof::from(&value.circuit_proof),
+            r: ProjectivePoint::from(value.r),
+        };
+    }
+}
+
+impl From<&Proof> for SerializableProof {
+    fn from(value: &Proof) -> Self {
+        return SerializableProof {
+            circuit_proof: circuit::SerializableProof::from(&value.circuit_proof),
+            r: value.r.to_affine(),
+        };
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,10 +6,9 @@ mod tests {
     use k256::elliptic_curve::rand_core::OsRng;
     use k256::{ProjectivePoint, Scalar};
     use crate::circuit::{ArithmeticCircuit, PartitionType, Witness};
-    use crate::{circuit, range_proof, wnla};
-    use crate::range_proof::reciprocal;
+    use crate::{range_proof, wnla};
     use crate::range_proof::u64_proof::*;
-    use crate::util::{minus};
+    use crate::util::minus;
 
     #[test]
     fn u64_proof_works() {
@@ -36,11 +35,13 @@ mod tests {
         let mut pt = merlin::Transcript::new(b"u64 range proof");
         let proof = public.prove(x, &s, &mut pt, &mut rand);
 
-        println!("Commitment: {}", serde_json::to_string_pretty(&commitment.to_affine()).unwrap());
-        println!("Proof: {}", serde_json::to_string_pretty(&reciprocal::SerializableProof::from(&proof)).unwrap());
-
         let mut vt = merlin::Transcript::new(b"u64 range proof");
-        assert!(public.verify(&commitment, proof, &mut vt));
+
+        assert!(
+            public.verify(&commitment, proof.clone(), &mut vt),
+            "failed to verfiy proof {:?} with commitment {:?}",
+            commitment, proof,
+        );
     }
 
     #[test]
@@ -131,10 +132,12 @@ mod tests {
         let mut pt = merlin::Transcript::new(b"circuit test");
         let proof = circuit.prove::<OsRng>(&v, witness, &mut pt, &mut rand);
 
-        println!("{}", serde_json::to_string_pretty(&circuit::SerializableProof::from(&proof)).unwrap());
-
         let mut vt = merlin::Transcript::new(b"circuit test");
-        assert!(circuit.verify(&v, &mut vt, proof));
+        assert!(
+            circuit.verify(&v, &mut vt, proof.clone()),
+            "failed to verify with proof = {:?}",
+            proof,
+        );
     }
 
     #[test]
@@ -166,9 +169,12 @@ mod tests {
 
         let proof = wnla.prove(&commit, &mut pt, l, n);
 
-        println!("{}", serde_json::to_string_pretty(&wnla::SerializableProof::from(&proof)).unwrap());
-
         let mut vt = merlin::Transcript::new(b"wnla test");
-        assert!(wnla.verify(&commit, &mut vt, proof))
+
+        assert!(
+            wnla.verify(&commit, &mut vt, proof.clone()),
+            "failed to verify WNLA proof = {:?}",
+            proof,
+        )
     }
 }

--- a/src/wnla.rs
+++ b/src/wnla.rs
@@ -1,10 +1,12 @@
 ///! Definition and implementation of the Bulletproofs++ weight norm linear argument protocol.
 use std::ops::{Add, Mul};
-use k256::{AffinePoint, ProjectivePoint, Scalar};
+use k256::{ProjectivePoint, Scalar};
 use merlin::Transcript;
-use serde::{Deserialize, Serialize};
 use crate::transcript;
 use crate::util::*;
+
+#[cfg(feature = "serde")]
+mod serializable;
 
 /// Represents public information to be used in weight norm linear argument protocol.
 #[derive(Clone, Debug)]
@@ -26,37 +28,6 @@ pub struct Proof {
     pub x: Vec<ProjectivePoint>,
     pub l: Vec<Scalar>,
     pub n: Vec<Scalar>,
-}
-
-/// Represent serializable version of  weight norm linear argument proof (uses AffinePoint instead of ProjectivePoint).
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct SerializableProof {
-    pub r: Vec<AffinePoint>,
-    pub x: Vec<AffinePoint>,
-    pub l: Vec<Scalar>,
-    pub n: Vec<Scalar>,
-}
-
-impl From<&SerializableProof> for Proof {
-    fn from(value: &SerializableProof) -> Self {
-        return Proof {
-            r: value.r.iter().map(|r_val| ProjectivePoint::from(r_val)).collect::<Vec<ProjectivePoint>>(),
-            x: value.x.iter().map(|x_val| ProjectivePoint::from(x_val)).collect::<Vec<ProjectivePoint>>(),
-            l: value.l.clone(),
-            n: value.n.clone(),
-        };
-    }
-}
-
-impl From<&Proof> for SerializableProof {
-    fn from(value: &Proof) -> Self {
-        return SerializableProof {
-            r: value.r.iter().map(|r_val| r_val.to_affine()).collect::<Vec<AffinePoint>>(),
-            x: value.x.iter().map(|x_val| x_val.to_affine()).collect::<Vec<AffinePoint>>(),
-            l: value.l.clone(),
-            n: value.n.clone(),
-        };
-    }
 }
 
 impl WeightNormLinearArgument {

--- a/src/wnla/serializable.rs
+++ b/src/wnla/serializable.rs
@@ -1,0 +1,34 @@
+use k256::{AffinePoint, ProjectivePoint, Scalar};
+
+use super::Proof;
+
+/// Represent serializable version of  weight norm linear argument proof (uses AffinePoint instead of ProjectivePoint).
+#[derive(Clone, Debug)]
+pub struct SerializableProof {
+    pub r: Vec<AffinePoint>,
+    pub x: Vec<AffinePoint>,
+    pub l: Vec<Scalar>,
+    pub n: Vec<Scalar>,
+}
+
+impl From<&SerializableProof> for Proof {
+    fn from(value: &SerializableProof) -> Self {
+        return Proof {
+            r: value.r.iter().map(ProjectivePoint::from).collect::<Vec<ProjectivePoint>>(),
+            x: value.x.iter().map(ProjectivePoint::from).collect::<Vec<ProjectivePoint>>(),
+            l: value.l.clone(),
+            n: value.n.clone(),
+        };
+    }
+}
+
+impl From<&Proof> for SerializableProof {
+    fn from(value: &Proof) -> Self {
+        return SerializableProof {
+            r: value.r.iter().map(|r_val| r_val.to_affine()).collect::<Vec<AffinePoint>>(),
+            x: value.x.iter().map(|x_val| x_val.to_affine()).collect::<Vec<AffinePoint>>(),
+            l: value.l.clone(),
+            n: value.n.clone(),
+        };
+    }
+}


### PR DESCRIPTION
This change makes the `serde` dependency optional to reduce the total number of dependencies from 57 to 51 using `--no-default-features` flag.

Also for simpler maintainablity, moved `SerializableProof` into separate `serializable` modules, so by placing `#[cfg(feature = "serde")]` above it's declaration the whole implementations and structures became optional (instead of placing `#[cfg(feature = "serde")]` above each of them).

Removed usage of `serde` inside tests for more prefered `Debug` implementations.