### PR TITLE
Include README as crate doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ and `Deserialize` was implemented.
 Use [tests](./src/tests.rs) to run the provided example:
 
 ```rust
-pub fn main() {
+use k256::elliptic_curve::{Group, rand_core::OsRng};
+use k256::ProjectivePoint;
+
+use bp_pp::range_proof;
+use bp_pp::range_proof::u64_proof::G_VEC_FULL_SZ;
+use bp_pp::range_proof::u64_proof::H_VEC_FULL_SZ;
+use bp_pp::range_proof::reciprocal::{SerializableProof, self};
+
+fn main() {
     let mut rand = OsRng::default();
 
     let x = 123456u64; // private value to create proof for.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
 pub mod wnla;
 pub mod circuit;
 pub(crate) mod transcript;


### PR DESCRIPTION
This change makes two main profits:

* The entry point in the doc site of the crate always will be its README which will exclude the need of repeting the same things inside the `lib.rs` and README itself.

* After inclusion of the README as a doc, all the code inside it will be evaludated as Rust _doc test_ which will keep the code examples up-to-date.